### PR TITLE
Server: Fix input underruns

### DIFF
--- a/src/inputpipe.c
+++ b/src/inputpipe.c
@@ -114,6 +114,12 @@ int inputpipe_handle(inputpipe_ctx *ctx) {
 	return 0;
 }
 
+
+void inputpipe_uninit(inputpipe_ctx *ctx) {
+	chunk_free_members(&ctx->chunk);
+	close(ctx->fd);
+}
+
 void inputpipe_init(inputpipe_ctx *ctx) {
 	uint32_t c = snapctx.samples * snapctx.channels * snapctx.frame_size * snapctx.readms / 1000;
 	ctx->chunksize = c;

--- a/src/inputpipe.c
+++ b/src/inputpipe.c
@@ -52,7 +52,7 @@ int inputpipe_handle(inputpipe_ctx *ctx) {
 	struct timespec ctime;
 	obtainsystime(&ctime);
 
-	struct timespec start_playing_at = timeAddMs(&ctime, snapctx.bufferms * 9 / 10);  // target 90% buffer fill-rate to allow for some negative clock drift.
+	struct timespec start_playing_at = timeAddMs(&ctime, 100);
 	struct timespec bufferfull = timeAddMs(&ctime, snapctx.bufferms * 95 / 100 );
 	bool buffer_full = (timespec_cmp(ctx->lastchunk, bufferfull) > 0);
 

--- a/src/inputpipe.h
+++ b/src/inputpipe.h
@@ -53,4 +53,5 @@ typedef struct {
  * @return -1 on buffer overrun, 1 on chunk complete, 0 otherwise
  */
 int inputpipe_handle(inputpipe_ctx *ctx);
+void inputpipe_uninit(inputpipe_ctx *ctx);
 void inputpipe_init(inputpipe_ctx *ctx);

--- a/src/inputpipe.h
+++ b/src/inputpipe.h
@@ -42,12 +42,15 @@ typedef struct {
 	ssize_t data_read;
 	int fd;
 
-	int chunksize;
+	uint16_t chunksize;
+	uint32_t pipelength_ms;
 	struct timespec lastchunk;
 	taskqueue_t *idle_task;
 } inputpipe_ctx;
-// return -1 on buffer overrun
-// return 1 on chunk complete
-// 0 otherwise
+
+/** inputpipe_handle() will read the data from the audio pipe feeding data.
+ * @param the inputpipe context
+ * @return -1 on buffer overrun, 1 on chunk complete, 0 otherwise
+ */
 int inputpipe_handle(inputpipe_ctx *ctx);
 void inputpipe_init(inputpipe_ctx *ctx);

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -550,7 +550,7 @@ void intercom_send_audio(intercom_ctx *ctx, pcmChunk *chunk) {
 	memcpy(&packet[packet_len], chunk->data, chunk->size);
 	packet_len += chunk->size;
 
-	print_packet(packet, packet_len);
+	// print_packet(packet, packet_len);
 
 	audio_packet ap;
 	ap.data = snap_alloc(packet_len);

--- a/src/server.c
+++ b/src/server.c
@@ -114,7 +114,7 @@ void loop() {
 			} else {
 				char buffer[512];
 				int tmp = read(events[i].data.fd, buffer, 512);
-				log_error("  WE JUST READ %i Byte from unknown socket %i or with unknown event with content %s\n", tmp,
+				exit_error("  WE JUST READ %i Byte from unknown socket %i or with unknown event with content %s\n", tmp,
 					  events[i].data.fd, buffer);
 			}
 		}


### PR DESCRIPTION
MPD is dropping data when using the fifo plugin. Getting snapcast ready to use the pipe plugin which does not drop data and induces slightly different behavior when pausing/unpausing.