### PR TITLE
alsaplayer: do not set start threshold

### DIFF
--- a/src/alsaplayer.c
+++ b/src/alsaplayer.c
@@ -130,14 +130,14 @@ int getchunk(pcmChunk *p, size_t delay_frames) {
 		is_close = timespec_isnear(&ts_alsa_ready, &nextchunk_playat, NOT_EVEN_CLOSE_MS);
 		attempting_start_and_overshot = ((!snapctx.alsaplayer_ctx.playing) && (timespec_cmp(ts_alsa_ready, nextchunk_playat) >= 0));
 
-		chunk_is_in_past = (tdiff.sign > 0 && ! is_near && ! attempting_start_and_overshot);
+		chunk_is_in_past = (tdiff.sign > 0 && !is_near && !attempting_start_and_overshot);
 
-		if (chunk_is_in_past && ! is_close && ! chunk_is_empty(p)) {
+		if (chunk_is_in_past && !is_close && !chunk_is_empty(p)) {
 			log_error("we are behind by %s seconds: dropping this chunk!\n", print_timespec(&tdiff.time));
 			intercom_getnextaudiochunk(&snapctx.intercom_ctx, p);
 			chunk_free_members(p);
 		}
-	} while (chunk_is_in_past && ! is_close && ! chunk_is_empty(p));
+	} while (chunk_is_in_past && !is_close && !chunk_is_empty(p));
 
 	if (snapctx.alsaplayer_ctx.playing || (attempting_start_and_overshot) || is_near) {
 		intercom_getnextaudiochunk(&snapctx.intercom_ctx, p);
@@ -160,7 +160,7 @@ int getchunk(pcmChunk *p, size_t delay_frames) {
 			adjust_speed(p, ts_alsa_ready);
 	} else {
 		int sleep_ms = NOT_EVEN_CLOSE_MS;
-		if (tdiff.sign > 0 )
+		if (tdiff.sign > 0)
 			sleep_ms = 0;
 		else if (tdiff.time.tv_sec == 0)
 			sleep_ms = tdiff.time.tv_nsec / 1000000L;

--- a/src/alsaplayer.c
+++ b/src/alsaplayer.c
@@ -442,8 +442,8 @@ void alsaplayer_init(alsaplayer_ctx *ctx) {
 
 	snd_pcm_sw_params_set_avail_min(ctx->pcm_handle, ctx->swparams, ctx->frames);
 
-	snd_pcm_sw_params_set_start_threshold(ctx->pcm_handle, ctx->swparams, buffer_size);
-	log_verbose("start threshold is: %d\n", buffer_size);
+	snd_pcm_sw_params_set_start_threshold(ctx->pcm_handle, ctx->swparams, buffer_size / 2);
+	log_verbose("start threshold is: %d\n", buffer_size / 2);
 
 	snd_pcm_sw_params(ctx->pcm_handle, ctx->swparams);
 	ctx->initialized = true;


### PR DESCRIPTION
This avoids symptoms that playback simply does not continue on raspi.
Not sure why, however it does work without threshold.