### PR TITLE
intercom: Retransmit handling

### DIFF
--- a/src/intercom.c
+++ b/src/intercom.c
@@ -68,14 +68,18 @@ int receivebuffer_cmp(const void *d1, const void *d2) {
 	return chunk_cmp(c2, c1);  // we want smallest first
 }
 
+void realloc_intercom_buffer(intercom_ctx *ctx, size_t elements) {
+	log_verbose("Adjusting an initializing local buffer size to %d elements. Previous size: %d elements.\n", elements,
+		    ctx->receivebuffer ? ctx->receivebuffer->capacity : 0);
+	pqueue_delete(ctx->receivebuffer);
+	ctx->receivebuffer = pqueue_new(receivebuffer_cmp, elements);
+}
+
 void realloc_intercom_buffer_when_required(intercom_ctx *ctx, int serverbufferms, size_t chunk_ms) {
 	// should we be able to do this when retaining the content of the buffer?
 	size_t calculated_elements = serverbufferms / chunk_ms + 1;
 	if (!ctx->receivebuffer || calculated_elements != ctx->receivebuffer->capacity) {
-		log_verbose("Adjusting local buffer size to %d ms/%d elements. Previous size: %d ms of data in %d elements.\n", serverbufferms,
-			    calculated_elements, chunk_ms, ctx->receivebuffer ? ctx->receivebuffer->capacity : 0);
-		pqueue_delete(ctx->receivebuffer);
-		ctx->receivebuffer = pqueue_new(receivebuffer_cmp, calculated_elements);
+		realloc_intercom_buffer(ctx, calculated_elements);
 		snapctx.bufferms = serverbufferms;
 	}
 }
@@ -356,6 +360,7 @@ bool remove_request(uint32_t nonce) {
 	if (ap) {
 		int i = VECTOR_GETINDEX(snapctx.intercom_ctx.missing_packets, ap);
 		VECTOR_DELETE(snapctx.intercom_ctx.missing_packets, i);
+		log_verbose("removing request %lu from missing_packets vector index %d\n", nonce, i);
 		return true;
 	}
 	return false;
@@ -397,7 +402,6 @@ void request_task(void *d) {
 			ndata->check_task = post_task(&snapctx.taskqueue_ctx, 0, 100, request_task, free, ndata);
 		} else {
 			log_debug("Could not find request for id %lu - it was most likely already served.\n", req_nonce);
-			remove_request(req_nonce);
 		}
 	} else {
 		log_error("no more retries left for packet with id %lu - we are missing data due to shaky network. This will be audible.\n",
@@ -448,7 +452,7 @@ void prune_missing_packets(intercom_ctx *ctx, uint32_t oldestnonce) {
 	for (int i = VECTOR_LEN(ctx->missing_packets) - 1; i >= 0; --i) {
 		audio_packet *ap = &VECTOR_INDEX(ctx->missing_packets, i);
 
-		if (ap->nonce < oldestnonce) {
+		if (ap->nonce <= oldestnonce) {
 			VECTOR_DELETE(ctx->missing_packets, i);
 			log_error("deleting outdated packet from missing packets vector\n");
 		}
@@ -470,6 +474,7 @@ bool intercom_handle_audio(intercom_ctx *ctx, intercom_packet_audio *packet, int
 	memcpy(chunk->data, &((uint8_t *)packet)[currentoffset], chunk->size);
 
 	size_t this_seqno = ntohl(packet->hdr.nonce);
+	remove_request(this_seqno);  // we received the packet all right. Let's not request it again.
 
 	// when buffer is empty, it may not have been initialized and thus the server may have adjusted its chunk size.
 	log_debug("handling audio data\n");
@@ -483,69 +488,77 @@ bool intercom_handle_audio(intercom_ctx *ctx, intercom_packet_audio *packet, int
 	    .tv_sec = chunk->play_at_tv_sec, .tv_nsec = chunk->play_at_tv_nsec,
 	};
 
-	log_verbose("read chunk from packet: %d samples: %d frame size:%d  channels: %d packet_len: %d, hdrsize: %d, play_at %s\n", chunk->size,
-		    chunk->samples, chunk->frame_size, chunk->channels, packet_len, sizeof(intercom_packet_audio), print_timespec(&play_at));
-
-	if (!is_next_chunk(this_seqno) &&
-	    (this_seqno > ctx->mtu / sizeof(tlv_request) && (this_seqno - ctx->lastreceviedseqno < ctx->mtu / sizeof(tlv_request)))) {
-		struct timespec ctime;
-		obtainsystime(&ctime);
-		log_error("Packet loss for %lu packets detected: Last received audio chunk had seqno %lu, we just received %lu.\n",
-			  this_seqno - ctx->lastreceviedseqno - 1, ctx->lastreceviedseqno, this_seqno);
-
-		// TODO: place multiple TLV for request into a single packet for more efficiency
-		for (uint32_t i = max(ctx->lastreceviedseqno, this_seqno - ctx->receivebuffer->capacity) + 1; i < this_seqno; ++i) {
-			log_verbose("requested packet with seqno: %lu\n", i);
-			audio_packet ap = {.nonce = i};
-
-			audio_packet *already_requesting = VECTOR_LSEARCH(&ap, ctx->missing_packets, cmp_audiopacket);
-			if (!already_requesting) {
-				VECTOR_ADD(snapctx.intercom_ctx.missing_packets, ap);
-				limit_missing_packets(ctx, ctx->receivebuffer->capacity);
-				intercom_send_request(ctx, &ap);
-			}
-		}
-	} else if (!is_next_chunk(this_seqno) && (this_seqno - ctx->lastreceviedseqno > ctx->receivebuffer->capacity)) {
-		log_error("WARN: huge loss of %d packets detected. Resetting seqno. This will be audible\n", this_seqno - ctx->lastreceviedseqno);
-		ctx->lastreceviedseqno = this_seqno;
-	}
+	log_verbose("read chunk from packet: %d samples: %d frame size: %d channels: %d packet_len: %d, play_at %s\n", chunk->size, chunk->samples,
+		    chunk->frame_size, chunk->channels, packet_len, print_timespec(&play_at));
 
 	struct timespec ctime;
 	obtainsystime(&ctime);
 
 	if (timespec_cmp(play_at, ctime) > 0) {
+		if (!is_next_chunk(this_seqno)) {
+			bool is_chunk_retransmit = this_seqno < ctx->lastreceviedseqno;
+			bool is_chunk_far_in_future = (!is_chunk_retransmit) && this_seqno - ctx->lastreceviedseqno >= ctx->receivebuffer->capacity;
+
+			if (!is_chunk_retransmit) {
+				if (is_chunk_far_in_future) {
+					log_error("WARN: huge loss of %lu packets detected. Resetting seqno. This will be audible\n",
+						  this_seqno - ctx->lastreceviedseqno);
+					ctx->lastreceviedseqno = this_seqno;
+					realloc_intercom_buffer(ctx, ctx->receivebuffer->capacity);
+				} else {
+					log_error(
+					    "Packet loss for %lu packets detected: Last received audio chunk had seqno %lu, we just received %lu.\n",
+					    this_seqno - ctx->lastreceviedseqno - 1, ctx->lastreceviedseqno, this_seqno);
+
+					// TODO: place multiple TLV for request into a single packet for more efficiency
+					size_t max_requests = max(ctx->lastreceviedseqno, this_seqno - ctx->receivebuffer->capacity) + 1;
+					for (size_t i = max_requests; i < this_seqno; ++i) {
+						log_verbose("requested packet with seqno: %lu\n", i);
+						audio_packet ap = {.nonce = i};
+
+						audio_packet *already_requesting = VECTOR_LSEARCH(&ap, ctx->missing_packets, cmp_audiopacket);
+						if (!already_requesting) {
+							VECTOR_ADD(snapctx.intercom_ctx.missing_packets, ap);
+							limit_missing_packets(ctx, ctx->receivebuffer->capacity);
+							intercom_send_request(ctx, &ap);
+						}
+					}
+				}
+			}
+		}
+
 		log_debug("storing chunk\n");
 		intercom_put_chunk(ctx, chunk);
 		if (this_seqno > ctx->lastreceviedseqno)
 			ctx->lastreceviedseqno = this_seqno;
+
+		if (chunk->frame_size != snapctx.alsaplayer_ctx.frame_size || (chunk->channels != snapctx.alsaplayer_ctx.channels) ||
+		    (chunk->samples != snapctx.alsaplayer_ctx.rate)) {
+			log_error("chunk size is not equal to alsa init size - (re-)initializing with samples: %lu sample size: %d, channels %d\n",
+				  chunk->samples, chunk->frame_size, chunk->channels);
+			alsaplayer_uninit(&snapctx.alsaplayer_ctx);
+		}
+
+		if (!snapctx.alsaplayer_ctx.initialized) {
+			snapctx.alsaplayer_ctx.frame_size = chunk->frame_size;
+			snapctx.alsaplayer_ctx.channels = chunk->channels;
+			snapctx.alsaplayer_ctx.rate = chunk->samples;
+
+			alsaplayer_init(&snapctx.alsaplayer_ctx);
+			init_alsafd(&snapctx.alsaplayer_ctx);
+		}
+		return true;
 	} else {
-		log_error("discarding chunk %d (play at: %s) - too late to play, it is now %s.\n", this_seqno, print_timespec(&play_at),
+		log_error("discarding chunk %d (play at: %s) - too late, it is now %s.\n", this_seqno, print_timespec(&play_at),
 			  print_timespec(&ctime));
 		chunk_free_members(chunk);
 		free(chunk);
 		if (this_seqno > ctx->lastreceviedseqno) {
 			ctx->lastreceviedseqno = this_seqno;
-			prune_missing_packets(ctx, this_seqno);
 		}
+		prune_missing_packets(ctx, this_seqno);
 		return false;
 	}
-
-	if (chunk->frame_size != snapctx.alsaplayer_ctx.frame_size || (chunk->channels != snapctx.alsaplayer_ctx.channels) ||
-	    (chunk->samples != snapctx.alsaplayer_ctx.rate)) {
-		log_error("chunk size is not equal to alsa init size - (re-)initializing with samples: %lu sample size: %d, channels %d\n",
-			  chunk->samples, chunk->frame_size, chunk->channels);
-		alsaplayer_uninit(&snapctx.alsaplayer_ctx);
-	}
-
-	if (!snapctx.alsaplayer_ctx.initialized) {
-		snapctx.alsaplayer_ctx.frame_size = chunk->frame_size;
-		snapctx.alsaplayer_ctx.channels = chunk->channels;
-		snapctx.alsaplayer_ctx.rate = chunk->samples;
-
-		alsaplayer_init(&snapctx.alsaplayer_ctx);
-		init_alsafd(&snapctx.alsaplayer_ctx);
-	}
-	return true;
 }
 
 void intercom_handle_packet(intercom_ctx *ctx, uint8_t *packet, ssize_t packet_len, struct in6_addr *peer, uint16_t port) {


### PR DESCRIPTION
* Stop requesting audio chunks that we have already received
* refactor audio packet handling for more clarity

This fixes #29 