### PR TITLE
clientmgr: do not crash when attempting to delete unknown/empty client

### DIFF
--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -99,7 +99,7 @@ void delete_client_internal(stream *s, client_t *c) {
 		print_client(c);
 		stream_client_remove(s, c);
 	} else {
-		log_debug("Client [%lu] unknown: cannot delete\n", c->id);
+		log_error("Client [%lu] unknown: cannot delete\n", c ? c->id : 0);
 	}
 }
 

--- a/src/intercom_srv.c
+++ b/src/intercom_srv.c
@@ -82,7 +82,7 @@ int assemble_stop(uint8_t *packet, uint32_t nonce) {
 
 bool intercom_set_volume(intercom_ctx *ctx, const client_t *client, uint8_t volume) {
 	int packet_len = 0;
-	uint8_t *packet = snap_alloc(sizeof(intercom_packet_op) + sizeof(tlv_op));
+	uint8_t *packet = snap_alloc(sizeof(intercom_packet_op) + sizeof(tlv_op) + sizeof(volume));
 
 	stream *s = stream_find(client);
 	packet_len = assemble_header(&((intercom_packet_op *)packet)->hdr, SERVER_OPERATION, &s->nonce, 0);

--- a/src/intercom_srv.c
+++ b/src/intercom_srv.c
@@ -82,7 +82,7 @@ int assemble_stop(uint8_t *packet, uint32_t nonce) {
 
 bool intercom_set_volume(intercom_ctx *ctx, const client_t *client, uint8_t volume) {
 	int packet_len = 0;
-	uint8_t *packet = snap_alloc(sizeof(intercom_packet_op) + sizeof(tlv_op) + sizeof(volume));
+	uint8_t packet[sizeof(intercom_packet_op) + sizeof(tlv_op) + sizeof(volume)];
 
 	stream *s = stream_find(client);
 	packet_len = assemble_header(&((intercom_packet_op *)packet)->hdr, SERVER_OPERATION, &s->nonce, 0);
@@ -93,7 +93,7 @@ bool intercom_set_volume(intercom_ctx *ctx, const client_t *client, uint8_t volu
 
 bool intercom_stop_client(intercom_ctx *ctx, const client_t *client) {
 	int packet_len = 0;
-	uint8_t *packet = snap_alloc(sizeof(intercom_packet_op) + sizeof(tlv_op));
+	uint8_t packet[sizeof(intercom_packet_op) + sizeof(tlv_op)];
 
 	stream *s = stream_find(client);
 	packet_len = assemble_header(&((intercom_packet_op *)packet)->hdr, SERVER_OPERATION, &s->nonce, 0);

--- a/src/pcmchunk.c
+++ b/src/pcmchunk.c
@@ -18,7 +18,7 @@ void get_emptychunk(pcmChunk *ret, unsigned int length_ms) {
 	ret->play_at_tv_nsec = 0L;
 	ret->data = snap_alloc0(ret->size);
 	ret->codec = CODEC_PCM;
-	log_verbose("generated chunks with size %d and length %lu ms\n", ret->size, length_ms);
+	log_debug("generated chunks with size %d and length %lu ms\n", ret->size, length_ms);
 }
 
 struct timespec chunk_get_play_at(pcmChunk *chunk) {


### PR DESCRIPTION
This is a round of a few fixes:
* off by one error when allocating memory is fixed in the server. While this already should address the crash that  the first patch is safeguarding from, checking the client data structure before printing it is a good idea anways
* memory leak from intercom_srv - client operations were not freed after sending, leading to leak in the server
* logging in the client is reduced on buffer underruns, addressing #43 