### PR TITLE
Cleanup and Memory fixes

### DIFF
--- a/src/alsaplayer.c
+++ b/src/alsaplayer.c
@@ -134,7 +134,8 @@ int getchunk(pcmChunk *p, size_t delay_frames) {
 		chunk_is_in_past = (tdiff.sign > 0 && !is_near && !attempting_start_and_overshot);
 
 		if (chunk_is_in_past && !is_close && !chunk_is_empty(p)) {
-			log_error("we are behind by %s seconds: dropping this chunk!\n", print_timespec(&tdiff.time));
+			log_error("we are behind by %s seconds: dropping chunk that was meant to be played at %s\n", print_timespec(&tdiff.time),
+				  print_timespec(&nextchunk_playat));
 			intercom_getnextaudiochunk(&snapctx.intercom_ctx, p);
 			chunk_free_members(p);
 		}

--- a/src/client.c
+++ b/src/client.c
@@ -227,9 +227,9 @@ int main(int argc, char *argv[]) {
 	snapctx.alsaplayer_ctx.initialized = false;
 
 	snapctx.bufferms = 1000;
-	snapctx.alsaplayer_ctx.card = strdup("default");
-	snapctx.alsaplayer_ctx.mixer = strdup("Master");
-	snapctx.alsaplayer_ctx.pcm.name = strdup("default");
+	snapctx.alsaplayer_ctx.card = snap_strdup("default");
+	snapctx.alsaplayer_ctx.mixer = snap_strdup("Master");
+	snapctx.alsaplayer_ctx.pcm.name = snap_strdup("default");
 
 	snapctx.intercom_ctx.port = INTERCOM_PORT;
 	snapctx.intercom_ctx.mtu = 1500;  // Do we need to expose this to the user via cli?
@@ -248,15 +248,15 @@ int main(int argc, char *argv[]) {
 				exit(EXIT_SUCCESS);
 			case 'c':
 				free(snapctx.alsaplayer_ctx.card);
-				snapctx.alsaplayer_ctx.card = strdup(optarg);
+				snapctx.alsaplayer_ctx.card = snap_strdup(optarg);
 				break;
 			case 'm':
 				free(snapctx.alsaplayer_ctx.mixer);
-				snapctx.alsaplayer_ctx.mixer = strdup(optarg);
+				snapctx.alsaplayer_ctx.mixer = snap_strdup(optarg);
 				break;
 			case 's':
 				free(snapctx.alsaplayer_ctx.pcm.name);
-				snapctx.alsaplayer_ctx.pcm.name = strdup(optarg);
+				snapctx.alsaplayer_ctx.pcm.name = snap_strdup(optarg);
 				break;
 			case 'l':
 				alsaplayer_pcm_list();
@@ -268,7 +268,7 @@ int main(int argc, char *argv[]) {
 				snapctx.intercom_ctx.nodeid = atol(optarg);
 				break;
 			case 'H':
-				snapctx.servername = strdup(optarg);
+				snapctx.servername = snap_strdup(optarg);
 				obtain_ip_from_name(optarg, &snapctx.intercom_ctx.serverip);
 				break;
 			case 'd':

--- a/src/inputpipe.c
+++ b/src/inputpipe.c
@@ -47,7 +47,7 @@ bool is_chunk_complete(inputpipe_ctx *ctx) { return (ctx->chunksize == ctx->data
 void set_idle(void *d) {
 	inputpipe_ctx *ctx = (inputpipe_ctx *)d;
 	if (ctx->idle_task)
-		taskqueue_remove(ctx->idle_task);
+		drop_task(ctx->idle_task);
 	log_verbose("INPUT_UNDERRUN... this will be audible.\n");
 	ctx->state = IDLE;
 	ctx->idle_task = NULL;

--- a/src/inputpipe.c
+++ b/src/inputpipe.c
@@ -59,7 +59,8 @@ int inputpipe_handle(inputpipe_ctx *ctx) {
 	obtainsystime(&ctime);
 
 	struct timespec bufferfull = timeAddMs(&ctime, snapctx.bufferms * 95 / 100);
-	bool buffer_full = (timespec_cmp(ctx->lastchunk, bufferfull) > 0);
+	struct timespec lastchunk_play_at = chunk_get_play_at(&ctx->chunk);
+	bool buffer_full = (timespec_cmp(lastchunk_play_at, bufferfull) > 0);
 
 	if (buffer_full)
 		return -1;
@@ -72,14 +73,19 @@ int inputpipe_handle(inputpipe_ctx *ctx) {
 		log_debug("read %d Bytes from inputpipe, data_read: %d chunksize: %d\n", count, ctx->data_read, ctx->chunksize);
 		ctx->state = IDLE;
 	} else if ((count > 0) && (ctx->state == IDLE)) {
-		struct timespec start_playing_at = timeAddMs(&ctime, COLD_START_OFFSET_MS);
+		struct timespec start_playing_at;
+
+		if (timespec_cmp(ctime, chunk_get_play_at(&ctx->chunk)) > 0) {
+			start_playing_at = timeAddMs(&ctime, COLD_START_OFFSET_MS);
+			log_verbose("Detected status change, resyncing timestamps. This will be audible.\n", ctx->state);
+		} else {
+			start_playing_at = timeAddMs(&lastchunk_play_at, ctx->read_ms);
+		}
+
 		ctx->data_read += count;
 		ctx->state = PLAYING;
 		ctx->chunk.play_at_tv_sec = start_playing_at.tv_sec;
 		ctx->chunk.play_at_tv_nsec = start_playing_at.tv_nsec;
-		ctx->lastchunk = chunk_get_play_at(&ctx->chunk);
-
-		log_verbose("Detected status change, resyncing timestamps. This will be audible.\n", ctx->state);
 
 		log_debug("read chunk that is to be played at %s, current time %s\n",
 			  print_timespec(&(struct timespec){.tv_sec = ctx->chunk.play_at_tv_sec, .tv_nsec = ctx->chunk.play_at_tv_nsec}),
@@ -96,9 +102,9 @@ int inputpipe_handle(inputpipe_ctx *ctx) {
 
 		if (timespec_cmp(ctime, play_at) > 0) {
 			log_error(
-			    "Either this is the first chunk we read for the first client on an inputstream or We are horribly late when reading from "
-			    "the pipes. Using current timestamp to play back current chunk. If this occurs during playback in contrast to the very "
-			    "beginning, consider adjusting timeout_ms for this stream.\n");
+			    "Either this is the first chunk we read for the first client on an inputstream or we are horribly late when reading from "
+			    "the pipes. Using current timestamp to play back current chunk. This will be audible. If this occurs during playback in "
+			    "contrast to the very beginning, consider adjusting timeout_ms for this stream.\n");
 			play_at = timeAddMs(&ctime, COLD_START_OFFSET_MS);
 		} else {
 			play_at = timeAddMs(&play_at, ctx->read_ms);
@@ -107,7 +113,6 @@ int inputpipe_handle(inputpipe_ctx *ctx) {
 		timediff t = timeSub(&ctime, &play_at);
 		ctx->chunk.play_at_tv_sec = play_at.tv_sec;
 		ctx->chunk.play_at_tv_nsec = play_at.tv_nsec;
-		ctx->lastchunk = play_at;
 
 		log_verbose("read %lu Bytes of data from %s, last read was %lu, reader state: %s, to be played at %s, current time %s, diff: %c%s\n",
 			    ctx->data_read, ctx->fname, count, print_inputpipe_status(ctx->state), print_timespec(&play_at), print_timespec(&ctime),

--- a/src/inputpipe.h
+++ b/src/inputpipe.h
@@ -47,7 +47,6 @@ typedef struct {
 
 	uint16_t chunksize;
 	uint32_t pipelength_ms;
-	struct timespec lastchunk;
 	bool initialized;
 	taskqueue_t *resume_task;
 	taskqueue_t *idle_task;

--- a/src/intercom_client.c
+++ b/src/intercom_client.c
@@ -314,6 +314,12 @@ bool is_next_chunk(uint32_t seq) {
 		((seq - 1) == ctx->lastreceviedseqno && ctx->lastreceviedseqno != NONCE_MAX));
 };
 
+bool already_requesting(intercom_ctx *ctx, uint32_t nonce) {
+	audio_packet ap = {.nonce = nonce};
+	audio_packet *already_requesting = VECTOR_LSEARCH(&ap, ctx->missing_packets, cmp_audiopacket);
+	return !!already_requesting;
+}
+
 bool intercom_handle_audio(intercom_ctx *ctx, intercom_packet_audio *packet, int packet_len) {
 	// TODO: Implementing TLV format for audio data will de-couple readms from the packet size.
 	uint8_t *packetpointer = &((uint8_t *)packet)[sizeof(intercom_packet_audio)];
@@ -368,10 +374,9 @@ bool intercom_handle_audio(intercom_ctx *ctx, intercom_packet_audio *packet, int
 					size_t max_requests = max(ctx->lastreceviedseqno, this_seqno - ctx->receivebuffer->capacity) + 1;
 					for (size_t i = max_requests; i < this_seqno; ++i) {
 						log_verbose("requested packet with seqno: %lu\n", i);
-						audio_packet ap = {.nonce = i};
 
-						audio_packet *already_requesting = VECTOR_LSEARCH(&ap, ctx->missing_packets, cmp_audiopacket);
-						if (!already_requesting) {
+						if (!already_requesting(ctx, i)) {
+							audio_packet ap = {.nonce = i};
 							VECTOR_ADD(snapctx.intercom_ctx.missing_packets, ap);
 							limit_missing_packets(ctx, ctx->receivebuffer->capacity);
 							intercom_send_request(ctx, &ap);
@@ -422,9 +427,7 @@ void intercom_handle_packet(intercom_ctx *ctx, uint8_t *packet, ssize_t packet_l
 
 	if (hdr->version == PACKET_FORMAT_VERSION) {
 		if (intercom_recently_seen(ctx, hdr)) {
-			audio_packet ap = {.nonce = hdr->nonce};
-			audio_packet *already_requesting = VECTOR_LSEARCH(&ap, ctx->missing_packets, cmp_audiopacket);
-			if (already_requesting)
+			if (already_requesting(ctx, hdr->nonce))
 				log_error("DROPPING audio packet with id %lu which we have previously seen yet newly requested.\n", hdr->nonce);
 			else 
 				log_error("DROPPING audio packet with id %lu which we have previously seen.\n", hdr->nonce);

--- a/src/intercom_client.c
+++ b/src/intercom_client.c
@@ -373,13 +373,12 @@ bool intercom_handle_audio(intercom_ctx *ctx, intercom_packet_audio *packet, int
 					// TODO: place multiple TLV for request into a single packet for more efficiency
 					size_t max_requests = max(ctx->lastreceviedseqno, this_seqno - ctx->receivebuffer->capacity) + 1;
 					for (size_t i = max_requests; i < this_seqno; ++i) {
-						log_verbose("requested packet with seqno: %lu\n", i);
-
 						if (!already_requesting(ctx, i)) {
 							audio_packet ap = {.nonce = i};
 							VECTOR_ADD(snapctx.intercom_ctx.missing_packets, ap);
 							limit_missing_packets(ctx, ctx->receivebuffer->capacity);
 							intercom_send_request(ctx, &ap);
+							log_verbose("requested packet with seqno: %lu\n", i);
 						}
 					}
 				}

--- a/src/intercom_client.c
+++ b/src/intercom_client.c
@@ -224,7 +224,6 @@ void free_intercom_task(void *d) {
 
 void request_task(void *d) {
 	struct intercom_task *data = d;
-	struct intercom_task *ndata = snap_alloc0(sizeof(struct intercom_task));
 	intercom_packet_hdr *req = (intercom_packet_hdr *)data->packet;
 	req->nonce = get_nonce(&nonce);
 
@@ -234,6 +233,7 @@ void request_task(void *d) {
 		audio_packet key = {.nonce = req_nonce};
 		audio_packet *ap = VECTOR_LSEARCH(&key, snapctx.intercom_ctx.missing_packets, cmp_audiopacket);
 		if (ap) {
+			struct intercom_task *ndata = snap_alloc0(sizeof(struct intercom_task));
 			log_debug("Requesting missing packet with id %lu\n", req_nonce);
 			copy_intercom_task(data, ndata);
 			ndata->retries_left--;

--- a/src/intercom_client.c
+++ b/src/intercom_client.c
@@ -468,7 +468,10 @@ void intercom_reinit(void *d) {
 }
 
 void intercom_uninit(intercom_ctx *ctx) {
-	taskqueue_remove(ctx->hello_task);
+	free(((struct intercom_task*)(ctx->hello_task->data))->packet);
+	free(((struct intercom_task*)(ctx->hello_task->data))->recipient);
+	free(ctx->hello_task->data);
+	drop_task(ctx->hello_task);
 	close(ctx->fd);
 	ctx->lastreceviedseqno = 0;
 

--- a/src/intercom_client.c
+++ b/src/intercom_client.c
@@ -94,7 +94,7 @@ struct timespec intercom_get_time_next_audiochunk(intercom_ctx *ctx) {
 	return chunk_get_play_at(buf);
 }
 
-bool underrun = false;
+static bool underrun = false;
 
 void intercom_getnextaudiochunk(intercom_ctx *ctx, pcmChunk *ret) {
 	pcmChunk *c = pqueue_dequeue(ctx->receivebuffer);
@@ -108,6 +108,7 @@ void intercom_getnextaudiochunk(intercom_ctx *ctx, pcmChunk *ret) {
 		if (ret)
 			get_emptychunk(ret, 5);
 	} else {
+		underrun = false;
 		log_verbose("retrieved audio chunk [size: %d, samples: %d, channels: %d, timestamp %zu.%zu]  cached chunks: %zu/%zu\n", c->size,
 			    c->samples, c->channels, c->play_at_tv_sec, c->play_at_tv_nsec, ctx->receivebuffer->size, ctx->receivebuffer->capacity);
 		print_packet(c->data, c->size);

--- a/src/jsonrpc.c
+++ b/src/jsonrpc.c
@@ -76,7 +76,7 @@ bool jsonrpc_parse_string(jsonrpc_request *result, const char *line) {
 				parameter p;
 
 				p.type = json_object_get_type(val);
-				p.name = strdup(key);
+				p.name = snap_strdup(key);
 				log_debug("key: %s ", key);
 				switch (p.type) {
 					case json_type_null:
@@ -99,14 +99,14 @@ bool jsonrpc_parse_string(jsonrpc_request *result, const char *line) {
 						json_object *tmp = NULL;
 						if (!json_object_object_get_ex(params, key, &tmp))
 							log_error("could not get json object %s\n", key);
-						p.value.json_string = strdup(json_object_to_json_string(tmp));
+						p.value.json_string = snap_strdup(json_object_to_json_string(tmp));
 						break;
 					case json_type_array:
 						log_error("found json_type_array - NOT IMPLEMENTED. THIS SHOULD NOT HAPPEN.\n");
 						break;
 					case json_type_string:
 						log_debug("found json_type_string\n");
-						p.value.string = strdup(json_object_get_string(val));
+						p.value.string = snap_strdup(json_object_get_string(val));
 						break;
 				}
 				VECTOR_ADD(result->parameters, p);

--- a/src/pcmchunk.c
+++ b/src/pcmchunk.c
@@ -22,12 +22,7 @@ void get_emptychunk(pcmChunk *ret, unsigned int length_ms) {
 }
 
 struct timespec chunk_get_play_at(pcmChunk *chunk) {
-	struct timespec ret = {};
-	if (chunk) {
-		ret.tv_sec = chunk->play_at_tv_sec;
-		ret.tv_nsec = chunk->play_at_tv_nsec;
-	}
-	return ret;
+	return chunk ? (struct timespec){.tv_sec = chunk->play_at_tv_sec, .tv_nsec = chunk->play_at_tv_nsec} : (struct timespec){};
 }
 
 int chunk_getduration_ms(pcmChunk *chunk) {

--- a/src/stream.c
+++ b/src/stream.c
@@ -69,7 +69,7 @@ bool stream_parse(stream *s, const char *raw) {
 	char *optionctx = NULL;
 	char *valuectx = NULL;
 
-	s->raw = strdup(raw);
+	s->raw = snap_strdup(raw);
 
 	if (!strncmp(raw, "pipe", 4))
 		s->protocol = PIPE;
@@ -80,7 +80,7 @@ bool stream_parse(stream *s, const char *raw) {
 
 	token = strtok_r(strstr(s->raw, PROTOCOL_DELIMITER) + strlen(PROTOCOL_DELIMITER) * sizeof(char), "?", &optionctx);
 
-	s->inputpipe.fname = strdup(token);
+	s->inputpipe.fname = snap_strdup(token);
 
 	log_debug("found input: %s\n", s->inputpipe.fname);
 
@@ -96,7 +96,7 @@ bool stream_parse(stream *s, const char *raw) {
 			else if (!strcmp(token, "codec"))
 				s->codec = parse_codec(value);
 			else if (!strcmp(token, "name"))
-				s->name = strdup(value);
+				s->name = snap_strdup(value);
 			else if (!strcmp(token, "sampleformat")) {
 				valuectx = NULL;
 				value = strtok_r(value, ":", &valuectx);

--- a/src/taskqueue.c
+++ b/src/taskqueue.c
@@ -78,6 +78,7 @@ void drop_task(taskqueue_t *task) {
 		task->cleanup(task->data);
 
 	free(task);
+	task = NULL;
 }
 
 /** Changes the timeout of a task.

--- a/src/taskqueue.h
+++ b/src/taskqueue.h
@@ -35,6 +35,7 @@ void taskqueue_remove(taskqueue_t *elem);
 void taskqueue_init(taskqueue_ctx *ctx);
 void taskqueue_run(taskqueue_ctx *ctx);
 void taskqueue_schedule(taskqueue_ctx *ctx);
+void drop_task(taskqueue_t *ctx);
 taskqueue_t *post_task(taskqueue_ctx *ctx, time_t timeout, long millisecs, void (*function)(void *), void (*cleanup)(void *),
 		       void *data);
 bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task, time_t timeout, long millisecs);


### PR DESCRIPTION
This introduces a few fixes for 
- memleaks in the client
- silence every bufferms milliseconds due to alsa incorrectly un-initializing
- some minor code cleanups