### PR TITLE
Reduce CPU Load on Network Buffer Underrun

### DIFF
--- a/debian/default
+++ b/debian/default
@@ -1,2 +1,2 @@
-SNAPCAST_SERVEROPTS="-s "pipe:///tmp/snapfifo?name=default&codec=opus&sampleformat=48000:16:2&buffer_ms=120" -b 30000 -p 1704"
+SNAPCAST_SERVEROPTS="-b 25000 -s "pipe:///tmp/snapfifo?name=default&codec=opus&sampleformat=48000:16:2&buffer_ms=120" -p 1704"
 SNAPCAST_CLIENTOPTS="-s snapclient -m snapclient -H localhost -p 1704"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,8 @@ target_link_libraries(snapcast-test ${ALSA_LIBRARIES})
 target_link_libraries(snapcast-client ${JSON_C_LIBRARIES})
 target_link_libraries(snapcast-client ${ALSA_LIBRARIES})
 
-set_target_properties(snapcast-client PROPERTIES COMPILE_FLAGS "-std=gnu11 -fno-omit-frame-pointer -Wall" LINK_FLAGS "-lm")
-set_target_properties(snapcast-server PROPERTIES COMPILE_FLAGS "-std=gnu11 -fno-omit-frame-pointer -Wall" LINK_FLAGS "-lm")
+set_target_properties(snapcast-client PROPERTIES COMPILE_FLAGS "-std=gnu11 -fsanitize=address -fno-omit-frame-pointer -Wall" LINK_FLAGS "-lm -fsanitize=address")
+set_target_properties(snapcast-server PROPERTIES COMPILE_FLAGS "-std=gnu11 -fsanitize=address  -fno-omit-frame-pointer -Wall" LINK_FLAGS "-lm -fsanitize=address")
 set_target_properties(snapcast-test PROPERTIES COMPILE_FLAGS "-std=gnu11 -fno-omit-frame-pointer -Wall" LINK_FLAGS "-lm")
 
 install(TARGETS snapcast-client RUNTIME DESTINATION bin)

--- a/src/alsaplayer.c
+++ b/src/alsaplayer.c
@@ -151,14 +151,12 @@ int getchunk(pcmChunk *p, size_t delay_frames) {
 			snapctx.alsaplayer_ctx.playing = true;
 			snapctx.alsaplayer_ctx.empty_chunks_in_row = 0;
 			post_task(&snapctx.taskqueue_ctx, 0, 0, decode_first_input, NULL, NULL);
+			reschedule_task(&snapctx.taskqueue_ctx, snapctx.alsaplayer_ctx.close_task, (1.2 * snapctx.bufferms) / 1000,
+					(int)(1.2 * snapctx.bufferms) % 1000);
+			chunk_decode(p);
+			if (!is_near)
+				adjust_speed(p, ts_alsa_ready);
 		}
-		reschedule_task(&snapctx.taskqueue_ctx, snapctx.alsaplayer_ctx.close_task, (1.2 * snapctx.bufferms) / 1000,
-				(int)(1.2 * snapctx.bufferms) % 1000);
-
-		chunk_decode(p);
-
-		if (!is_near)
-			adjust_speed(p, ts_alsa_ready);
 	} else {
 		int sleep_ms = NOT_EVEN_CLOSE_MS;
 		if (tdiff.sign > 0)

--- a/src/alsaplayer.c
+++ b/src/alsaplayer.c
@@ -315,11 +315,9 @@ void alsaplayer_uninit(alsaplayer_ctx *ctx) {
 }
 
 void init_alsafd(alsaplayer_ctx *ctx) {
-	for (int i = 0; i < ctx->pollfd_count; i++) {
-		struct pollfd *pfd = &snapctx.alsaplayer_ctx.ufds[i];
-		ctx->main_poll_fd[i].fd = pfd->fd;
-		ctx->main_poll_fd[i].events = POLLIN;
-		ctx->main_poll_fd[i].revents = 0;
+	int err = 0;
+	if ((err = snd_pcm_poll_descriptors(ctx->pcm_handle, ctx->main_poll_fd, ctx->pollfd_count)) < 0) {
+		exit_error("Unable to obtain ALSA poll descriptors for audio playback: %s\n", snd_strerror(err));
 	}
 }
 

--- a/src/alsaplayer.c
+++ b/src/alsaplayer.c
@@ -136,14 +136,14 @@ int getchunk(pcmChunk *p, size_t delay_frames) {
 		if (chunk_is_in_past && !is_close && !chunk_is_empty(p)) {
 			log_error("we are behind by %s seconds: dropping chunk that was meant to be played at %s\n", print_timespec(&tdiff.time),
 				  print_timespec(&nextchunk_playat));
-			intercom_getnextaudiochunk(&snapctx.intercom_ctx, p);
-			chunk_free_members(p);
+			if (intercom_getnextaudiochunk(&snapctx.intercom_ctx, p))
+				chunk_free_members(p);
 		}
 	} while (chunk_is_in_past && !is_close && !chunk_is_empty(p));
 
 	if (snapctx.alsaplayer_ctx.playing || (attempting_start_and_overshot) || is_near) {
-		intercom_getnextaudiochunk(&snapctx.intercom_ctx, p);
-		if (chunk_is_empty(p)) {
+		if (!intercom_getnextaudiochunk(&snapctx.intercom_ctx, p)) {
+			get_emptychunk(p, 50);
 			snapctx.alsaplayer_ctx.empty_chunks_in_row++;
 			if (snapctx.alsaplayer_ctx.empty_chunks_in_row > 5)
 				snapctx.alsaplayer_ctx.playing = false;

--- a/src/client.c
+++ b/src/client.c
@@ -95,9 +95,9 @@ void loop() {
 	struct pollfd fds[fd_index + 2];  // allocate fds for alsa events
 	snapctx.alsaplayer_ctx.main_poll_fd = fds;  // alsa fds must be the first
 
+	// Alsa will be initialized when first packets arrive.
 	for (int i = 0; i < fd_index; i++) {
 		fds[i].fd = -1;
-		fds[i].events = POLLIN;
 	}
 
 	fds[fd_index].fd = snapctx.taskqueue_ctx.fd;

--- a/src/intercom_client.h
+++ b/src/intercom_client.h
@@ -20,6 +20,6 @@ void intercom_reinit(void *ctx);
 void intercom_init(intercom_ctx *ctx);
 void intercom_uninit(intercom_ctx *ctx);
 struct timespec intercom_get_time_next_audiochunk(intercom_ctx *ctx);
-void intercom_getnextaudiochunk(intercom_ctx *ctx, pcmChunk *c);
+bool intercom_getnextaudiochunk(intercom_ctx *ctx, pcmChunk *c);
 bool intercom_peeknextaudiochunk(intercom_ctx *ctx, pcmChunk **ret);
 

--- a/src/server.c
+++ b/src/server.c
@@ -93,8 +93,7 @@ void loop() {
 					stream *s = stream_find_fd(events[i].data.fd);
 					if (s) {
 						inputpipe_uninit(&s->inputpipe);
-						inputpipe_init(&s->inputpipe);
-						add_fd(snapctx.efd, s->inputpipe.fd, EPOLLIN);
+						inputpipe_resume_read(&s->inputpipe);
 					}
 				} else if (socket_get_client(&snapctx.socket_ctx, NULL, events[i].data.fd)) {
 					log_error("error received on one of the socket clients. Closing %d\n", events[i].data.fd);


### PR DESCRIPTION
Writing small amounts of data to alsa incurs significant CPU load. Since
848a490f we can create silence with fine-grained duration. We now can
save some CPU creating bigger chunks of silence on network buffer
underruns without overloading the client CPU.