### PR TITLE
This fixes two build issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,9 @@ node {
     }
   }
   stage('Test') {
-    sh "docker run -v $WORKSPACE:/$PROJECTDIR -a STDIN -a STDOUT -a STDERR snapcastc-build /$PROJECTDIR/build/src/snapcast-test > testlog 2>&1"
+    sh "docker run -v $WORKSPACE:/$PROJECTDIR -a STDIN -a STDOUT -a STDERR snapcastc-build /$PROJECTDIR/build/src/snapcast-test-client > testlog 2>&1"
+    sh "docker run -v $WORKSPACE:/$PROJECTDIR -a STDIN -a STDOUT -a STDERR snapcastc-build /$PROJECTDIR/build/src/snapcast-test-server > testlog 2>&1"
+    sh "cat testlog"
   }
   stage('Package') {
     parallel (

--- a/src/client.h
+++ b/src/client.h
@@ -27,7 +27,7 @@ typedef struct client {
 
 	taskqueue_t *purge_task;
 } client_t;
-opuscodec_ctx opuscodec;
+static opuscodec_ctx opuscodec;
 
 typedef VECTOR(struct client) client_vector;
 


### PR DESCRIPTION
* the jenkisn pipeline must execute the client and server tests. Since the split into client and server part this was broken
* The removal of fnocommon yielded a broken build when emptying the cache.